### PR TITLE
#22 - added manipulation of namespace to work with nested category.

### DIFF
--- a/K2Field.Powershell.Module/K2Field.Powershell.Module/NewK2Package.cs
+++ b/K2Field.Powershell.Module/K2Field.Powershell.Module/NewK2Package.cs
@@ -54,7 +54,31 @@ namespace K2Field.Powershell.Module
                 session.SetOption("NoAnalyze", true);
                 PackageItemOptions options = PackageItemOptions.Create();
                 options.ValidatePackage = Validate;
-                var typeRef = new TypeRef(Category, "urn:SourceCode/Categories");
+
+
+                var pathNamespace = "/root/";
+                var rootNamespace = "urn:SourceCode/Categories";
+                string ns;
+                string category;
+
+                if (Category.Contains("\\"))
+                {
+                    var categories = Category.Split('\\');
+
+                    var parentCats = string.Join("/", categories.Take(categories.Length - 1));
+                    pathNamespace += parentCats + "/";
+
+                    ns = rootNamespace + "?root#Path." + Uri.EscapeDataString(pathNamespace);
+                    category = categories.Last();
+                }
+                else
+                {
+                    ns = rootNamespace;
+                    category = Category;
+                }
+
+                var typeRef = new TypeRef(category, ns);
+
                 var query = QueryItemOptions.Create(typeRef);
                 var results = session.FindItems(query).Result;
                 foreach (var result in results)


### PR DESCRIPTION
I was looking at the way P&D puts categories in the XML files. Through testing was able to deduce that i could extend the namespace to include the ?root#Path and thereby limit the scope of the query.

Category Parameter will now accept "cat\sub". This category combination will only select the cat\subcat objects and references.  "Foo\sub" will not be selected.

using "Subcat" alone will still select both "cat\SubCat" and "foo\SubCat".

